### PR TITLE
Update prod settings for bcreg components.

### DIFF
--- a/openshift/templates/api/config/bcreg-base/prod/default.json
+++ b/openshift/templates/api/config/bcreg-base/prod/default.json
@@ -39,7 +39,7 @@
     "multiUse": true
   },
   "authentication": {
-    "jwksUri": "https://oidc.gov.bc.ca/auth/realms/gzyg46lx/protocol/openid-connect/certs",
+    "jwksUri": "https://test.oidc.gov.bc.ca/auth/realms/gzyg46lx/protocol/openid-connect/certs",
     "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/issuer-web/config/bcreg-registration/prod/config.json
+++ b/openshift/templates/issuer-web/config/bcreg-registration/prod/config.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "autoSignOut": true,
     "oidcSettings": {
-      "authority": "https://oidc.gov.bc.ca/auth/realms/gzyg46lx",
+      "authority": "https://test.oidc.gov.bc.ca/auth/realms/gzyg46lx",
       "clientId": "bcreg-registration-issuer",
       "redirectUri": "https://bcreg-registration-issuer.apps.silver.devops.gov.bc.ca/oidc-callback",
       "redirect_uri": "https://bcreg-registration-issuer.apps.silver.devops.gov.bc.ca/oidc-callback-error",

--- a/openshift/templates/issuer-web/config/bcreg-relations/prod/config.json
+++ b/openshift/templates/issuer-web/config/bcreg-relations/prod/config.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "autoSignOut": true,
     "oidcSettings": {
-      "authority": "https://oidc.gov.bc.ca/auth/realms/gzyg46lx",
+      "authority": "https://test.oidc.gov.bc.ca/auth/realms/gzyg46lx",
       "clientId": "bcreg-relationship-issuer",
       "redirectUri": "https://bcreg-relationship-issuer.apps.silver.devops.gov.bc.ca/oidc-callback",
       "redirect_uri": "https://bcreg-relationship-issuer.apps.silver.devops.gov.bc.ca/oidc-callback-error",


### PR DESCRIPTION
- Point them at the correct Keycloak realm.  Demo apps use the `test` realm connected to Sovrin StagingNet.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>