### PR TITLE
Update prod settings for citz components.

### DIFF
--- a/openshift/templates/api/config/bcgov-citz/prod/default.json
+++ b/openshift/templates/api/config/bcgov-citz/prod/default.json
@@ -39,7 +39,7 @@
     "multiUse": true
   },
   "authentication": {
-    "jwksUri": "https://oidc.gov.bc.ca/auth/realms/gzyg46lx/protocol/openid-connect/certs",
+    "jwksUri": "https://test.oidc.gov.bc.ca/auth/realms/gzyg46lx/protocol/openid-connect/certs",
     "algorithms": ["RS256"]
   }
 }

--- a/openshift/templates/issuer-web/config/bcgov-citz/prod/config.json
+++ b/openshift/templates/issuer-web/config/bcgov-citz/prod/config.json
@@ -12,7 +12,7 @@
     "enabled": true,
     "autoSignOut": true,
     "oidcSettings": {
-      "authority": "https://oidc.gov.bc.ca/auth/realms/gzyg46lx",
+      "authority": "https://test.oidc.gov.bc.ca/auth/realms/gzyg46lx",
       "clientId": "bcgov-citz-issuer",
       "redirectUri": "https://bcgov-citz-issuer.apps.silver.devops.gov.bc.ca/oidc-callback",
       "redirect_uri": "https://bcgov-citz-issuer.apps.silver.devops.gov.bc.ca/oidc-callback-error",


### PR DESCRIPTION
- Point them at the correct Keycloak realm.  Demo apps use the `test` realm.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>